### PR TITLE
Correction to MSBP Tag documentation

### DIFF
--- a/src/libs/lms/msbp.md
+++ b/src/libs/lms/msbp.md
@@ -110,6 +110,7 @@ If type is not 9:
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x1 | | Null terminated parameter name |
+| |0 to 3 | Align next param with 4 byte interval |
 
 If type is 9:
 
@@ -119,6 +120,7 @@ If type is 9:
 | 0x2 | 2 | Number of tag list items |
 | 0x4 | 2 per list item | List item indexes (in TGL2 block) |
 | | | Null terminated parameter name |
+| |0 to 3 | Align next param with 4 byte interval |
 
 ## TGL2 Block
 | Offset | Size | Description |
@@ -126,7 +128,7 @@ If type is 9:
 | 0x0 | 2 | Number of list items |
 | 0x2 | 2 | Padding |
 | 0x4 | 4 per list item | Offsets to list item names |
-| | | Null-terminated list item names |
+| | | Null-terminated list item names<br><i>(Unknown if requires 4 byte interval alignment</i>) |
 
 ## SYL3 Block
 | Offset | Size | Description |

--- a/src/libs/lms/msbp.md
+++ b/src/libs/lms/msbp.md
@@ -72,9 +72,11 @@ This block defines control tags for [MSBT files](msbt.md).
 ### Tag Group
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Number of tags |
-| 0x2 | 2 per tag | Tag indexes (in TAG2 block) |
+| 0x0 | 2 | Group index in block |
+| 0x2 | 2 | Number of tags |
+| 0x4 | 2 per tag | Tag indexes (in TAG2 block) |
 | | | Null-terminated tag group name |
+| |0 to 3 | Align next tag group with 4 byte interval |
 
 ## TAG2 Block
 | Offset | Size | Description |
@@ -89,6 +91,7 @@ This block defines control tags for [MSBT files](msbt.md).
 | 0x0 | 2 | Number of tag parameters |
 | 0x2 | 2 per parameter | Tag parameter indexes (in TGP2 block) |
 | | | Null-terminated tag name |
+| |0 to 3 | Align next tag with 4 byte interval |
 
 ## TGP2 Block
 | Offset | Size | Description |


### PR DESCRIPTION
## Summary
The MSBP block definitions of TGG2 (Tag Groups), TAG2 (Tags), and TPG2 (Tag Parameters) have missing pieces of information.

## Tag Groups are Missing Field
A Tag Group was previously defined as beginning with the number of tags in the group. This is incorrect however, it actually begins with the group's ID in the block. The ID is usually identical to the index in the TGG2 group offset list, but can be different as seen in Super Mario Odyssey's MSBP, jumping from group ID 11 to 201.

## Tag null-terminated strings also need alignment bytes
The other error fixed in this PR is how all three tag data block types aren't accurate with the null-terminated name strings. This string must always be aligned on a 0x4 interval of the binary. This means that after the null terminator, extra null bytes will be present until on the next interval (0x0, 0x4, 0x8, 0xC, `n % 4 == 0`)  
  
---

Super small pull request but an important tweak to make sure the docs are accurate! Thank you for all your work you've put into this website, been really helpful!