### PR TITLE
Add MSBF

### DIFF
--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -1,15 +1,12 @@
 ## [LMS](../../formats.md#lms) > [Overview](overview.md) > Flow Chart (MSBF)
 
-This file is identified by the magic number `MsgFlwBn`. The format is responsible for handling of actions defined by nodes.
+This file is identified by the magic number `MsgFlwBn`. The format is responsible for holding flowcharts.
 
 | Type | Description |
 | --- | --- |
 | `FLW3` | [Nodes](#flw3-Block) |
 | `FEN1` | [Flowchart Labels](#ref1-Block) |
 | `REF1` | ? |
-
-## FEN1 Block
-This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of it's Entry Node.
 
 ## FLW3 Block
 This section is responsible for holding all the [nodes](#Nodes).
@@ -23,7 +20,7 @@ This section is responsible for holding all the [nodes](#Nodes).
 |      | 2 per ID | [Branch table](#branch-table)
 |      |         | [String table](#string-table)
 
-## Nodes
+### Nodes
 Actions defined within the FLW3 Section are done via nodes. 
 
 | Offset | Size | Description |
@@ -34,7 +31,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | 0x04 | 2 | Subtype value |
 | 0x06 | 10 | Collection of 5 shorts |
 
-### Node Types
+#### Node Types
 | Value | Type | Description |
 | --- | --- | --- |
 | 0x01 | [Message](#message-node) | Prompts a message from a MSBT. |
@@ -107,15 +104,17 @@ Short data is specifc to the game and subtype of the node.
 
 0xFFFF marks the end of a flowchart for any node that isn't a branch node.
 
-## Branch Table
+### Branch Table
 Nodes that are branch will jump to a specifc case based on a condition.
 
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x00 |    | List of node IDs |
 
-
-## String Table 
+### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x00 |    | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |
+
+## FEN1 Block
+This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of it's Entry Node.

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -29,7 +29,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | 0x1 | 1|  [Subtype](#sub-types) |
 | 0x2 | 2 | Reserved |
 | 0x4 | 2 | Subtype value |
-| 0x6 | 10 | Collection of 5 shorts |
+| 0x6 | 10 | Node specifc data |
 
 #### Node Types
 | Value | Type | Description |
@@ -50,7 +50,7 @@ Implementations of type specifc data vary between game. These types are only val
 | 2 | Unknown | 
 | 3 | Unknown |
 | 4 | Unknown |
-| 5 | Offset from start of block to null-terminated string in the [string table](#string-table) | |
+| 5 | Offset from start of block to string in [string table](#string-table). Specific to Event and Branch nodes. |
 | 6 | Unknown |
 
 ### Message Node
@@ -114,7 +114,7 @@ Nodes that are branch will jump to a specifc case based on a condition.
 ### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |
+| 0x0 | | List of null-terminated strings. |
 
 ## FEN1 Block
 This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of it's Entry Node.

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -40,7 +40,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | 0x04 | [Entry](#entry-node) | Node that acts as a starting point. |
 | 0x05 | [Jump](#jump-node) | Jumps to a different node. |
 
-### Subtypes
+#### Subtypes
 Implementations of type specifc data vary between game. These types are only valid for Branch and Event nodes.
 
 | Value | Description |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -1,6 +1,6 @@
 ## [LMS](../../formats.md#lms) > [Overview](overview.md) > Flow Chart (MSBF)
 
-This file is identified by the magic number `MsgFlwBn`. The format is responsible for handling of event actions defined by nodes.
+This file is identified by the magic number `MsgFlwBn`. The format is responsible for handling of actions defined by nodes.
 
 | Type | Description |
 | --- | --- |
@@ -105,7 +105,7 @@ Short data is specifc to the game and subtype of the node.
 | 0x6 | 2 | Unused  |
 | 0x8 | 2 | Unused  |
 
-0xFFFF marks the end of a flowchart.
+0xFFFF marks the end of a flowchart for any node that isn't a branch node.
 
 ## Branch Table
 Nodes that are branch will jump to a specifc case based on a condition.

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -25,33 +25,33 @@ Actions defined within the FLW3 Section are done via nodes.
 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x00 | 1 | [Node type](#node-types) |
-| 0x01 | 1|  [Subtype](#sub-types) |
-| 0x02 | 2 | Reserved |
-| 0x04 | 2 | Subtype value |
-| 0x06 | 10 | Collection of 5 shorts |
+| 0x0 | 1 | [Node type](#node-types) |
+| 0x1 | 1|  [Subtype](#sub-types) |
+| 0x2 | 2 | Reserved |
+| 0x4 | 2 | Subtype value |
+| 0x6 | 10 | Collection of 5 shorts |
 
 #### Node Types
 | Value | Type | Description |
 | --- | --- | --- |
-| 0x01 | [Message](#message-node) | Prompts a message from a MSBT. |
-| 0x02 | [Branch](#branch-node) | Branches into different nodes based on a condition. |
-| 0x03 | [Event](#event-node) | Pompts an action or event. | 
-| 0x04 | [Entry](#entry-node) | Node that acts as a starting point. |
-| 0x05 | [Jump](#jump-node) | Jumps to a different node. |
+| 1 | [Message](#message-node) | Prompts a message from a MSBT. |
+| 2 | [Branch](#branch-node) | Branches into different nodes based on a condition. |
+| 3 | [Event](#event-node) | Pompts an action or event. | 
+| 4 | [Entry](#entry-node) | Node that acts as a starting point. |
+| 5 | [Jump](#jump-node) | Jumps to a different node. |
 
 #### Subtypes
 Implementations of type specifc data vary between game. These types are only valid for Branch and Event nodes.
 
 | Value | Description |
 | --- | --- |
-| 0x00 | Unknown |
-| 0x01 | Unknown |
-| 0x02 | Unknown | 
-| 0x03 | Unknown |
-| 0x04 | Unknown |
-| 0x05 | Offset from start of block to null-terminated string in the [string table](#string-table) | |
-| 0x06 | Unknown |
+| 0 | Unknown |
+| 1 | Unknown |
+| 2 | Unknown | 
+| 3 | Unknown |
+| 4 | Unknown |
+| 5 | Offset from start of block to null-terminated string in the [string table](#string-table) | |
+| 6 | Unknown |
 
 ### Message Node
 | Offset | Size | Description |
@@ -109,12 +109,12 @@ Nodes that are branch will jump to a specifc case based on a condition.
 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x00 |    | List of node IDs |
+| 0x0 |    | List of node IDs |
 
 ### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x00 |    | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |
+| 0x0 |    | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |
 
 ## FEN1 Block
 This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of it's Entry Node.

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -1,9 +1,121 @@
 ## [LMS](../../formats.md#lms) > [Overview](overview.md) > Flow Chart (MSBF)
 
-This file is identified by the magic number `MsgFlwBn`.
+This file is identified by the magic number `MsgFlwBn`. The format is responsible for handling of event actions defined by nodes.
 
 | Type | Description |
 | --- | --- |
-| `FLW3` | ? |
-| `FEN1` | ? |
+| `FLW3` | [Nodes](#flw3-Block) |
+| `FEN1` | [Flowchart Labels](#ref1-Block) |
 | `REF1` | ? |
+
+## FEN1 Block
+This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of it's Entry Node.
+
+## FLW3 Block
+This section is responsible for holding all the [nodes](#Nodes).
+
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x0 | 2  | Node count |
+| 0x2 | 2  | Branch table node count  (See [branch table](#branch-table)) |
+| 0x4 | 12 | Padding |
+| 0x10 | 16 per node | [Nodes](#Nodes)
+|      | 2 per ID | [Branch table](#branch-table)
+|      |         | [String table](#string-table)
+
+## Nodes
+Actions defined within the FLW3 Section are done via nodes. 
+
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x00 | 1 | [Node type](#node-types) |
+| 0x01 | 1|  [Subtype](#sub-types) |
+| 0x02 | 2 | Reserved |
+| 0x04 | 2 | Subtype value |
+| 0x06 | 10 | Collection of 5 shorts |
+
+### Node Types
+| Value | Type | Description |
+| --- | --- | --- |
+| 0x01 | [Message](#message-node) | Prompts a message from a MSBT. |
+| 0x02 | [Branch](#branch-node) | Branches into different nodes based on a condition. |
+| 0x03 | [Event](#event-node) | Pompts an action or event. | 
+| 0x04 | [Entry](#entry-node) | Node that acts as a starting point. |
+| 0x05 | [Jump](#jump-node) | Jumps to a different node. |
+
+### Subtypes
+Implementations of type specifc data vary between game. These types are only valid for Branch and Event nodes.
+
+| Value | Description |
+| --- | --- |
+| 0x00 | Unknown |
+| 0x01 | Unknown |
+| 0x02 | Unknown | 
+| 0x03 | Unknown |
+| 0x04 | Unknown |
+| 0x05 | Offset from start of block to null-terminated string in the [string table](#string-table) | |
+| 0x06 | Unknown |
+
+### Message Node
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x0 | 2 | Unused  |
+| 0x2 | 2 | Next node index |
+| 0x4 | 2 | MSBT file index  |
+| 0x6 | 2 | TXT2 message index |
+| 0x8 | 2 | Unused |
+
+### Branch Node 
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x0 | 2 | Short 1  |
+| 0x2 | 2 | 0xFFFF (always as next node index) |
+| 0x4 | 2 | Short 3 |
+| 0x6 | 2 | Branch table case count |
+| 0x8 | 2 | Starting index into the branch table |
+
+Short data is specifc to the game and subtype of the node.
+
+### Event Node
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x0 | 2 | Short 1  |
+| 0x2 | 2 | Next node index |
+| 0x4 | 2 | Short 3  |
+| 0x6 | 2 | Short 4  |
+| 0x8 | 2 | Short 5  |
+
+Short data is specifc to the game and subtype of the node.
+
+### Entry Node
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x0 | 2 | Unused  |
+| 0x2 | 2 | Next node index |
+| 0x4 | 2 | Unused   |
+| 0x6 | 2 | Unused   |
+| 0x8 | 2 | Unused   |
+
+### Jump Node
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x0 | 2 | Unused  |
+| 0x2 | 2 | Next node index |
+| 0x4 | 2 | Unused  |
+| 0x6 | 2 | Unused  |
+| 0x8 | 2 | Unused  |
+
+0xFFFF marks the end of a flowchart.
+
+## Branch Table
+Nodes that are branch will jump to a specifc case based on a condition.
+
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x00 |    | List of node IDs |
+
+
+## String Table 
+| Offset | Size | Description |
+| --- | --- | --- |
+| 0x00 |    | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -4,21 +4,21 @@ This file is identified by the magic number `MsgFlwBn`. The format is responsibl
 
 | Type | Description |
 | --- | --- |
-| `FLW3` | [Nodes](#flw3-Block) |
-| `FEN1` | [Flowchart Labels](#ref1-Block) |
+| `FLW3` | [Nodes](##flw3-block) |
+| `FEN1` | [Flowchart Labels](##ref1-block) |
 | `REF1` | ? |
 
 ## FLW3 Block
-This section is responsible for holding all the [nodes](#Nodes).
+This section is responsible for holding all the [nodes](#nodes).
 
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 2  | Node count |
-| 0x2 | 2  | Branch table node count  (See [branch table](#branch-table)) |
+| 0x2 | 2  | Branch table ID count |
 | 0x4 | 12 | Padding |
-| 0x10 | 16 per node | [Nodes](#Nodes)
-|      | 2 per ID | [Branch table](#branch-table)
-|      |         | [String table](#string-table)
+| 0x10 | 16 per node | [Nodes](#nodes)
+| | 2 per ID | [Branch table](#branch-table) |
+| | | [String table](#string-table)
 
 ### Nodes
 Actions defined within the FLW3 Section are done via nodes. 
@@ -89,18 +89,18 @@ Short data is specifc to the game and subtype of the node.
 | --- | --- | --- |
 | 0x0 | 2 | Unused  |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | Unused   |
-| 0x6 | 2 | Unused   |
-| 0x8 | 2 | Unused   |
+| 0x4 | 2 | Unused |
+| 0x6 | 2 | Unused |
+| 0x8 | 2 | Unused |
 
 ### Jump Node
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 2 | Unused  |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | Unused  |
-| 0x6 | 2 | Unused  |
-| 0x8 | 2 | Unused  |
+| 0x4 | 2 | Unused |
+| 0x6 | 2 | Unused |
+| 0x8 | 2 | Unused |
 
 0xFFFF marks the end of a flowchart for any node that isn't a branch node.
 
@@ -109,12 +109,12 @@ Nodes that are branch will jump to a specifc case based on a condition.
 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 |    | List of node IDs |
+| 0x0 || List of node IDs |
 
 ### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 |    | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |
+| 0x0 | | List of null-terminated strings. Only referenced by Event nodes with type of 0x5. |
 
 ## FEN1 Block
 This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of it's Entry Node.


### PR DESCRIPTION
# Description
This PR adds most of the data for the MSBF file format from LMS. The main goal of making this PR is to bring awareness to this format to assist with decompiling it further. The nature of it is quite game specific, and would benefit from a lot of extra research.  Here is a list of SOME games that utilize the format:

* Tomodachi Life
* Nintendo Badge Arcade
* The Legend of Zelda: A Link Between Worlds
* The Legend of Zelda: Skyward Sword
* The Legend of Zelda: Triforce Heros
* Animal Crossing: New Leaf
* Animal Crossing: Amiibo Festival

# Sources
* I have decompiled most of the functions on my repository of a [LMS decomp](https://github.com/AbdyyEee/LibMessageStudio/blob/main/src/flowchart.c). This could be more accurate as I am new to reverse engineering. This was done by utilizing Splatoon 2's symbols to trace back functions from Triforce Heros and Tomodachi Life.
* Names and subtypes were taken from `SampleFlowchart.msbf` in Tomodachi Life which has `FEN1` flowcharts describing each node type and subtypes.
* Some signatures and return types for functions taken from [SS decomp](https://github.com/zeldaret/ss/blob/5dd7182857fb8a0ef67ae568a9e4490373313c05/src/libms/flowfile.c#L6)

Any feedback is appreciated as this is a format I'm really passionate on researching about :) 