### PR TITLE
MSBF: Subtype -> Parameter and Node Structure Fixes

### DIFF
--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -26,7 +26,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 1 | [Node type](#node-types) |
-| 0x1 | 1|  [Parameter type](#parameter-types) (Only for [Branch Nodes](#branch-node) & [Event Nodes](#event-node))|
+| 0x1 | 1|  [Parameter type](#parameter-types) (Only for [Branch Nodes](#branch-node) and [Event Nodes](#event-node))|
 | 0x2 | 2 | Reserved |
 | 0x4 | 4 | Parameter value |
 | 0x6 | 8 | Node data |
@@ -51,7 +51,7 @@ Parameter types dictate how parameter values may be passed into the node if it t
 | 3 | Unknown |
 | 4 | Unknown |
 | 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table). |
-| 6 | Unknown |
+| 6 | Raw value, used as is. |
 
 ### Message Node
 | Offset | Size | Description |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -5,7 +5,7 @@ This file is identified by the magic number `MsgFlwBn`. The format holds flowcha
 | Type | Description |
 | --- | --- |
 | `FLW3` | [Nodes](#flw3-block) |
-| `FEN1` | [Flowchart Labels](#ref1-block) |
+| `FEN1` | [Flowchart Labels](#fen1-block) |
 | `REF1` | ? |
 
 ## FLW3 Block
@@ -26,7 +26,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 1 | [Node type](#node-types) |
-| 0x1 | 1|  [Subtype](#sub-types) |
+| 0x1 | 1|  [Subtype](#sub-types) (`0xFF` if not Branch or Event node)|
 | 0x2 | 2 | Reserved |
 | 0x4 | 2 | Subtype value |
 | 0x6 | 10 | Node specifc data |
@@ -41,17 +41,16 @@ Actions defined within the FLW3 Section are done via nodes.
 | 5 | [Jump](#jump-node) | Jumps to a different node. |
 
 #### Subtypes
-Implementations of type specifc data vary between game. These types are only valid for Branch and Event nodes.
-
+Subtypes define values that modify how an Event or Branch node is run. Subtype implemenation varies per game. 
 | Value | Description |
 | --- | --- |
-| 0 | Unknown |
-| 1 | Unknown |
-| 2 | Unknown | 
-| 3 | Unknown |
-| 4 | Unknown |
-| 5 | Offset from start of block to string in [string table](#string-table). Specific to Event and Branch nodes. |
-| 6 | Unknown |
+| 0 | Game specifc |
+| 1 | Game specifc |
+| 2 | Game specifc | 
+| 3 | Game specifc |
+| 4 | Game specifc |
+| 5 | Offset from start of block to string in [string table](#string-table). |
+| 6 | Game specifc |
 
 ### Message Node
 | Offset | Size | Description |
@@ -66,7 +65,7 @@ Implementations of type specifc data vary between game. These types are only val
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 2 | Short 1  |
-| 0x2 | 2 | 0xFFFF (always as next node index) |
+| 0x2 | 2 | `0xFFFF` (always as next node index) |
 | 0x4 | 2 | Short 3 |
 | 0x6 | 2 | Branch table case count |
 | 0x8 | 2 | Starting index into the branch table |
@@ -82,7 +81,7 @@ Short data is specifc to the game and subtype of the node.
 | 0x6 | 2 | Short 4  |
 | 0x8 | 2 | Short 5  |
 
-Short data is specifc to the game and subtype of the node.
+How each short is utilized varies per game.
 
 ### Entry Node
 | Offset | Size | Description |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -26,7 +26,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 1 | [Node type](#node-types) |
-| 0x1 | 1|  [Parameter type](#parameter-types) (Only valid for [Branch Nodes](#branch-node) or [Event Nodes](#event-node))|
+| 0x1 | 1|  [Parameter type](#parameter-types) (Only for [Branch Nodes](#branch-node) & [Event Nodes](#event-node))|
 | 0x2 | 2 | Reserved |
 | 0x4 | 4 | Parameter value |
 | 0x6 | 8 | Node data |
@@ -46,7 +46,7 @@ Parameter types dictate how values may be passed into the node if it takes argum
 | Value | Description |
 | --- | --- |
 | 0 | Unknown |
-| 1 | Value is stored as two seperate short values. |
+| 1 | Values are stored as two seperate shorts. |
 | 2 | Unknown | 
 | 3 | Unknown |
 | 4 | Unknown |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -87,10 +87,10 @@ The node identifier allows a game to link the node to a specific action or condi
 ### Jump Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | Next flowchart |
+| 0x2 | 2 | Flowchart index|
 | 0x4 | 6 | Unused |
 
-The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to the Entry node of another flowchart.
+The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to the index of the Entry node fpr another flowchart.
 
 ### Branch Table
 Nodes that are branch will jump to a specifc case based on a condition. These function like Switch statements.

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -41,12 +41,12 @@ Actions defined within the FLW3 Section are done via nodes.
 | 5 | [Jump](#jump-node) | Jumps to a different flowchart. |
 
 #### Parameter Types
-Parameter types dictate how values may be passed into the node if it takes arguments. There may be more than one value passed into a node.
+Parameter types dictate how parameter values may be passed into the node if it takes arguments. There may be more than one value passed into a node.
 
 | Value | Description |
 | --- | --- |
-| 0 | Unknown |
-| 1 | Values are stored as two seperate shorts. |
+| 0 | Raw value, used as is. |
+| 1 | Stored as two seperate shorts. |
 | 2 | Unknown | 
 | 3 | Unknown |
 | 4 | Unknown |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -45,13 +45,13 @@ Parameter types dictate how parameter values may be passed into the node if it t
 
 | Value | Description |
 | --- | --- |
-| 0 | Raw value, used as is. |
+| 0 | 4 byte integer. |
 | 1 | Stored as two seperate shorts. |
 | 2 | Unknown | 
 | 3 | Unknown |
 | 4 | Unknown |
 | 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table). |
-| 6 | Raw value, used as is. |
+| 6 | 4 byte integer. |
 
 ### Message Node
 | Offset | Size | Description |

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -34,31 +34,31 @@ Actions defined within the FLW3 Section are done via nodes.
 #### Node Types
 | Value | Type | Description |
 | --- | --- | --- |
-| 1 | [Message](#message-node) | Prompts a message from a MSBT. |
-| 2 | [Branch](#branch-node) | Branches into different nodes based on a condition. |
-| 3 | [Event](#event-node) | Prompts an action or event. | 
-| 4 | [Entry](#entry-node) | Node that acts as a starting point. |
-| 5 | [Jump](#jump-node) | Jumps to a different flowchart. |
+| 1 | [Message](#message-node) | Prompts a message from a MSBT file |
+| 2 | [Branch](#branch-node) | Branches to a different node depending on a specific condition. |
+| 3 | [Event](#event-node) | Executes a specific action or game event. | 
+| 4 | [Entry](#entry-node) | Node that acts as a starting point for a flowchart |
+| 5 | [Jump](#jump-node) | Jumps  to a different flowchart |
 
 #### Parameter Types
 Parameter types dictate how parameter values may be passed into the node if it takes arguments. There may be more than one value passed into a node.
 
 | Value | Description |
 | --- | --- |
-| 0 | 4 byte integer. |
-| 1 | Stored as two seperate shorts. |
+| 0 | 4 byte integer |
+| 1 | Pair of 2 byte integers |
 | 2 | Unknown | 
 | 3 | Unknown |
 | 4 | Unknown |
-| 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table). |
-| 6 | 4 byte integer. |
+| 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table) |
+| 6 | 4 byte integer |
 
 ### Message Node
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | [MSBT](./msbt.md) file index |
-| 0x6 | 2 | Message index into [TXT2](./msbt.md#txt2-block) |
+| 0x4 | 2 | [MSBT](msbt.md) file index |
+| 0x6 | 2 | Message index into [TXT2](msbt.md#txt2-block) |
 | 0x8 | 2 | Unused |
 
 ### Branch Node 
@@ -87,10 +87,10 @@ The node identifier allows a game to link the node to a specific action or condi
 ### Jump Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | Next node index |
+| 0x2 | 2 | Next flowchart |
 | 0x4 | 6 | Unused |
 
-The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to an Entry node.
+The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to the Entry node of another flowchart.
 
 ### Branch Table
 Nodes that are branch will jump to a specifc case based on a condition. These function like Switch statements.
@@ -102,7 +102,7 @@ Nodes that are branch will jump to a specifc case based on a condition. These fu
 ### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | | List of encoded strings. |
+| 0x0 || List of strings | 
 
 ## FEN1 Block
 This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of its Entry [node](#nodes).

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -29,7 +29,7 @@ Actions defined within the FLW3 Section are done via nodes.
 | 0x1 | 1|  [Parameter type](#parameter-types) (Only for [Branch Nodes](#branch-node) and [Event Nodes](#event-node))|
 | 0x2 | 2 | Reserved |
 | 0x4 | 4 | Parameter value |
-| 0x6 | 8 | Node data |
+| 0x8 | 8 | Node data |
 
 #### Node Types
 | Value | Type | Description |
@@ -102,7 +102,7 @@ Nodes that are branch will jump to a specifc case based on a condition. These fu
 ### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 || List of strings | 
+| 0x0 || List of null-terminated strings | 
 
 ## FEN1 Block
 This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of its Entry [node](#nodes).

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -26,85 +26,74 @@ Actions defined within the FLW3 Section are done via nodes.
 | Offset | Size | Description |
 | --- | --- | --- |
 | 0x0 | 1 | [Node type](#node-types) |
-| 0x1 | 1|  [Subtype](#sub-types) (`0xFF` if not Branch or Event node)|
+| 0x1 | 1|  [Parameter type](#parameter-types) (Only valid for [Branch Nodes](#branch-node) or [Event Nodes](#event-node))|
 | 0x2 | 2 | Reserved |
-| 0x4 | 2 | Subtype value |
-| 0x6 | 10 | Node specifc data |
+| 0x4 | 4 | Parameter value |
+| 0x6 | 8 | Node data |
 
 #### Node Types
 | Value | Type | Description |
 | --- | --- | --- |
 | 1 | [Message](#message-node) | Prompts a message from a MSBT. |
 | 2 | [Branch](#branch-node) | Branches into different nodes based on a condition. |
-| 3 | [Event](#event-node) | Pompts an action or event. | 
+| 3 | [Event](#event-node) | Prompts an action or event. | 
 | 4 | [Entry](#entry-node) | Node that acts as a starting point. |
-| 5 | [Jump](#jump-node) | Jumps to a different node. |
+| 5 | [Jump](#jump-node) | Jumps to a different flowchart. |
 
-#### Subtypes
-Subtypes define values that modify how an Event or Branch node is run. Subtype implemenation varies per game. 
+#### Parameter Types
+Parameter types dictate how values may be passed into the node if it takes arguments. There may be more than one value passed into a node.
+
 | Value | Description |
 | --- | --- |
-| 0 | Game specifc |
-| 1 | Game specifc |
-| 2 | Game specifc | 
-| 3 | Game specifc |
-| 4 | Game specifc |
-| 5 | Offset from start of block to string in [string table](#string-table). |
-| 6 | Game specifc |
+| 0 | Unknown |
+| 1 | Value is stored as two seperate short values. |
+| 2 | Unknown | 
+| 3 | Unknown |
+| 4 | Unknown |
+| 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table). |
+| 6 | Unknown |
 
 ### Message Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Unused  |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | MSBT file index  |
-| 0x6 | 2 | TXT2 message index |
+| 0x4 | 2 | [MSBT](./msbt.md) file index |
+| 0x6 | 2 | Message index into [TXT2](./msbt.md#txt2-block) |
 | 0x8 | 2 | Unused |
 
 ### Branch Node 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Short 1  |
-| 0x2 | 2 | `0xFFFF` (always as next node index) |
-| 0x4 | 2 | Short 3 |
+| 0x2 | 2 | `0xFFFF`|
+| 0x4 | 2 | Node Identifier |
 | 0x6 | 2 | Branch table case count |
 | 0x8 | 2 | Starting index into the branch table |
-
-Short data is specifc to the game and subtype of the node.
 
 ### Event Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Short 1  |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | Short 3  |
-| 0x6 | 2 | Short 4  |
-| 0x8 | 2 | Short 5  |
+| 0x4 | 2 | Node identifier |
+| 0x6 | 4 | Unused |
 
-How each short is utilized varies per game.
+The node identifier allows a game to link the node to a specific action or condition. 
 
 ### Entry Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Unused  |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | Unused |
-| 0x6 | 2 | Unused |
-| 0x8 | 2 | Unused |
+| 0x4 | 6 | Unused |
 
 ### Jump Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Unused  |
 | 0x2 | 2 | Next node index |
-| 0x4 | 2 | Unused |
-| 0x6 | 2 | Unused |
-| 0x8 | 2 | Unused |
+| 0x4 | 6 | Unused |
 
-0xFFFF marks the end of a flowchart for any node that isn't a branch node.
+The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to an Entry node.
 
 ### Branch Table
-Nodes that are branch will jump to a specifc case based on a condition.
+Nodes that are branch will jump to a specifc case based on a condition. These function like Switch statements.
 
 | Offset | Size | Description |
 | --- | --- | --- |
@@ -113,7 +102,7 @@ Nodes that are branch will jump to a specifc case based on a condition.
 ### String Table 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | | List of null-terminated strings. |
+| 0x0 | | List of encoded strings. |
 
 ## FEN1 Block
-This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of its entry [node](#nodes).
+This block contains the flowchart [labels](overview.md#hash-tables). The index of a flowchart is the location of its Entry [node](#nodes).


### PR DESCRIPTION
Hello again! While working back on MSBF, I did a bit more research into the format and stumbled across a few things.

First off, Subtype has been converted naming wise into parameter. Subtypes are not used as identifiers at all, and rather modify how the parameter is passed into a node. I have so far figured out that  parameter type 1 does not use the full 4 bytes for a single value, but rather stores two separate values and passes those in.  Parameter type 0 and 6 just passes the 4 byte parameter value directly.

The above finding led to the proper structure for all the nodes. They now start with the next node id short. For `Branch` and `Event`, a single short value used is most often the identifier for the node so the game knows what function to run for it.

Fixed a few formatting things too and a typo.

Thanks.

