### PR TITLE
MSBF: Document Remaining Types

### DIFF
--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -35,8 +35,8 @@ Actions defined within the FLW3 Section are done via nodes.
 | Value | Type | Description |
 | --- | --- | --- |
 | 1 | [Message](#message-node) | Prompts a message from a MSBT file |
-| 2 | [Branch](#branch-node) | Branches to a different node depending on a specific condition. |
-| 3 | [Event](#event-node) | Executes a specific action or game event. | 
+| 2 | [Branch](#branch-node) | Branches to a different node depending on a specific condition |
+| 3 | [Event](#event-node) | Executes a specific action or game event | 
 | 4 | [Entry](#entry-node) | Node that acts as a starting point for a flowchart |
 | 5 | [Jump](#jump-node) | Jumps  to a different flowchart |
 
@@ -87,7 +87,7 @@ The node identifier allows a game to link the node to a specific action or condi
 ### Jump Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x0 | 2 | Flowchart index|
+| 0x0 | 2 | Flowchart index |
 | 0x2 | 6 | Unused |
 
 The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to the index of the entry node for another flowchart.

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -56,39 +56,39 @@ Parameter types dictate how parameter values may be passed into the node if it t
 ### Message Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | Next node index |
-| 0x4 | 2 | [MSBT](msbt.md) file index |
-| 0x6 | 2 | Message index into [TXT2](msbt.md#txt2-block) |
-| 0x8 | 2 | Unused |
+| 0x0 | 2 | Next node index |
+| 0x2 | 2 | [MSBT](msbt.md) file index |
+| 0x4 | 2 | Message index into [TXT2](msbt.md#txt2-block) |
+| 0x6 | 2 | Unused |
 
 ### Branch Node 
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | `0xFFFF`|
-| 0x4 | 2 | Node Identifier |
-| 0x6 | 2 | Branch table case count |
-| 0x8 | 2 | Starting index into the branch table |
+| 0x0 | 2 | `0xFFFF`|
+| 0x2 | 2 | Node Identifier |
+| 0x4 | 2 | Branch table case count |
+| 0x6 | 2 | Starting index into the branch table |
 
 ### Event Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | Next node index |
-| 0x4 | 2 | Node identifier |
-| 0x6 | 4 | Unused |
+| 0x0 | 2 | Next node index |
+| 0x2 | 2 | Node identifier |
+| 0x4 | 4 | Unused |
 
 The node identifier allows a game to link the node to a specific action or condition. 
 
 ### Entry Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | Next node index |
-| 0x4 | 6 | Unused |
+| 0x0 | 2 | Next node index |
+| 0x2 | 6 | Unused |
 
 ### Jump Node
 | Offset | Size | Description |
 | --- | --- | --- |
-| 0x2 | 2 | Flowchart index|
-| 0x4 | 6 | Unused |
+| 0x0 | 2 | Flowchart index|
+| 0x2 | 6 | Unused |
 
 The next node index when marked as `0xFFFF` is the end of a flowchart unless it is a branch node. The next node for a jump node must refer to the index of the entry node for another flowchart.
 

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -46,10 +46,10 @@ Parameter types dictate how parameter values may be passed into the node if it t
 | Value | Description |
 | --- | --- |
 | 0 | 4 byte integer |
-| 1 | Pair of 2 byte integers |
-| 2 | Unknown | 
-| 3 | Unknown |
-| 4 | Unknown |
+| 1 | 2 byte integer pair |
+| 2 | 2 byte integer followed by a pair of 1 byte integers | 
+| 3 | Pair of 1 byte integers followed by a 2 byte integer |
+| 4 | Array of 1 byte integers |
 | 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table) |
 | 6 | 4 byte integer |
 

--- a/src/libs/lms/msbf.md
+++ b/src/libs/lms/msbf.md
@@ -45,13 +45,13 @@ Parameter types dictate how parameter values may be passed into the node if it t
 
 | Value | Description |
 | --- | --- |
-| 0 | 4 byte integer |
-| 1 | 2 byte integer pair |
-| 2 | 2 byte integer followed by a pair of 1 byte integers | 
-| 3 | Pair of 1 byte integers followed by a 2 byte integer |
-| 4 | Array of 1 byte integers |
+| 0 | Int32 value |
+| 1 | Pair of Int16 values |
+| 2 | Int16 value followed by a pair of Int8 values | 
+| 3 | Pair of Int8 values followed by a Int16 value |
+| 4 | Array of Int8 values |
 | 5 | String value. Stored as an offset from start of block to the string in the [string table](#string-table) |
-| 6 | 4 byte integer |
+| 6 | Int32 value |
 
 ### Message Node
 | Offset | Size | Description |


### PR DESCRIPTION
Hi again.

I have documented the remaining types, and will describe them briefly. Parameter type 2 stores an Int16 followed by two Int8 values. Type 3 is the opposite, storing two Int8 values then an Int16. Type 4 is just an array of Int8 values.

This is probably the final documentation needed for the format, apart from `REF1` which I have not found a single game use (in revision 3/4 of LMS at the very least), so for now will remain empty. 

Appreciate it.